### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,17 +181,20 @@ async def healthz():
         redisHint = ""
     except Exception as e:
         redisStatus = False
-        redisHint = str(e)
+        logging.error("Redis error: %s", str(e))
+        redisHint = "An error occurred with Redis"
     # check mysql connection
     try:
         await test_db_connection()
         mysqlStatus = True
     except ConnectionError as e:
         mysqlStatus = False
-        mysqlHint = str(e)
+        logging.error("MySQL connection error: %s", str(e))
+        mysqlHint = "A connection error occurred with MySQL"
     except Exception as e:
         mysqlStatus = False
-        mysqlHint = str(e)
+        logging.error("MySQL error: %s", str(e))
+        mysqlHint = "An error occurred with MySQL"
     try:
         live_servers = await redis_client.get("InstanceRegister")
         if live_servers:
@@ -209,8 +212,8 @@ async def healthz():
                                      "live_servers": live_servers})
     else:
         return JSONResponse(content={"status": "error", "redis": redisStatus, "mysql": mysqlStatus,
-                                     "redis_hint": redisHint if not redisStatus else "",
-                                     "mysql_hint": mysqlHint if not mysqlStatus else "",
+                                     "redis_hint": "An error occurred" if not redisStatus else "",
+                                     "mysql_hint": "An error occurred" if not mysqlStatus else "",
                                      "live_servers": live_servers})
 
 


### PR DESCRIPTION
Fixes [https://github.com/binaryYuki/oleapi/security/code-scanning/1](https://github.com/binaryYuki/oleapi/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception information is not exposed to the client. Instead, we should log the exception details on the server and return a generic error message to the client. This can be achieved by modifying the exception handling code to use logging for the detailed error messages and providing a generic error message in the JSON response.

1. Import the `logging` module if not already imported.
2. Replace the direct assignment of exception messages to `redisHint` and `mysqlHint` with logging statements.
3. Return a generic error message in the JSON response instead of the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了健康检查端点的错误处理和日志记录。
  
- **错误修复**
  - 标准化了Redis和MySQL错误的JSON响应提示，避免暴露具体异常信息。

- **样式**
  - 进行了代码格式的小调整，包括去除多余空格和修正缩进问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->